### PR TITLE
cylon-i2c dependency fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "cylon": "^0.16.0",
     "cylon-gpio": "^0.16.0",
     "cylon-raspi": "^0.10.0",
-    "cylon.i2c": "^0.13.0",
+    "cylon-i2c": "^0.13.0",
     "express": "^4.4.1",
     "method-override": "^2.1.1",
     "swig": "^1.4.1"


### PR DESCRIPTION
npm install dependency for cylon-i2c is broken due typo error
